### PR TITLE
Don't delete the build directory root

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+# Ensure wildcards in globs match dotfiles too.
+shopt -s dotglob
+
 indent() {
     sed -u 's/^/      /'
 }
@@ -34,8 +38,8 @@ fi
             mv -v "${BUILD_DIR}/${DEPENDENCY}" "${TARGET}"
         done
     fi &&
-    rm -rf "${BUILD_DIR}" &&
-    mv "${STAGE}/$(basename "$APP_BASE")" "${BUILD_DIR}"
+    rm -rf "${BUILD_DIR}"/* &&
+    mv "${STAGE}/$(basename "$APP_BASE")"/* "${BUILD_DIR}"
 )
 
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
Hi

I'm on the team that maintains Heroku's build system and official buildpacks.

Very soon we are going to make a change to the Heroku build system that will mean builds using this buildpack fail with errors like:

```
remote: -----> Monorepo app detected
remote: rm: cannot remove '/app': Read-only file system
remote:       FAILED to copy directory into place
remote:  !     Push rejected, failed to compile Monorepo app.
```

A fix for this compatibility issue has been merged into the upstream repository from which this one is a fork of a fork:
https://github.com/lstoll/heroku-buildpack-monorepo/pull/13

This PR cherry-picks that change (with conflicts resolved).

For more information as to why this change is needed, see:
https://github.com/lstoll/heroku-buildpack-monorepo/issues/12

cc @morrislaptop 